### PR TITLE
fix(codex): seed config.toml per machine instead of symlinking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ shfmt -w <file>
 - `agents/opencode/opencode.jsonc` → `~/.config/opencode/opencode.jsonc`
 - `agents/opencode/tui.json` → `~/.config/opencode/tui.json`
 - `agents/opencode/themes/catppuccin-mocha.json` → `~/.config/opencode/themes/catppuccin-mocha.json`
-- `agents/codex/config.toml` → `~/.codex/config.toml`
+- `agents/codex/config.toml` → seeded (copied once, not symlinked) to `~/.codex/config.toml`; Codex writes machine-specific state there
 - `agents/openai/settings.json` → `~/.openai/settings.json`
 
 ### OBS Studio Configuration (`obs/`)

--- a/agents/README.md
+++ b/agents/README.md
@@ -27,6 +27,8 @@
 
 `instructions/learnings` is a repo-relative symlink to `../learnings`, so the `@./learnings/...` import resolves correctly whether a tool follows the home-directory symlink or the real file path.
 
+Exception: `codex/config.toml` is a portable seed that `links.sh` copies (once, if missing) to `~/.codex/config.toml` instead of symlinking. Codex writes machine-specific state into that file (project trust levels, marketplace sources, notify hooks), which must never land in the repo. Put shared Codex defaults in the seed; machine state stays local.
+
 ## How to extend
 
 - New durable preference: append to `learnings/preferences.md`.
@@ -40,6 +42,6 @@
 ## Rules
 
 - Edit files here, never the home-directory symlinks.
-- Portable paths only (`~/.dotfiles`, `~/.config/agents`). No machine-specific usernames, absolute home paths, or keys.
+- Portable paths only (`~/.dotfiles`, `~/.config/agents`). No machine-specific usernames, absolute home paths, or keys. These dotfiles run on multiple Macs with different account names; anything under `/Users/<name>/` breaks the other machine.
 - No secrets anywhere in this tree.
 - Do not add a `~/.gemini/skills` symlink; Gemini already loads `~/.agents/skills` and would warn about duplicates.

--- a/agents/codex/config.toml
+++ b/agents/codex/config.toml
@@ -1,83 +1,19 @@
-# Global OpenAI Codex CLI configuration.
-# Shared instructions are symlinked to ~/.codex/AGENTS.md.
-# Shared prompts are symlinked to ~/.codex/prompts.
+# Global OpenAI Codex CLI configuration (portable seed).
+#
+# links.sh COPIES this file to ~/.codex/config.toml on first install instead
+# of symlinking it, because Codex writes machine-specific state into the file
+# (project trust levels, marketplace sources, notify hooks, plugin paths).
+# Keep only portable, shared defaults here; never machine-specific paths.
+#
+# Shared instructions arrive via the ~/.codex/AGENTS.md symlink.
+# Shared prompts arrive via the ~/.codex/prompts symlink.
 
-notify = ["/Users/rckstrbhushan/.codex/computer-use/Codex Computer Use.app/Contents/SharedSupport/SkyComputerUseClient.app/Contents/MacOS/SkyComputerUseClient", "turn-ended"]
 model = "gpt-5.5"
 model_reasoning_effort = "high"
 service_tier = "default"
 
-[marketplaces.openai-bundled]
-last_updated = "2026-06-10T16:24:46Z"
-source_type = "local"
-source = "/Users/rckstrbhushan/.codex/.tmp/bundled-marketplaces/openai-bundled"
-
-[marketplaces.openai-primary-runtime]
-last_updated = "2026-06-05T09:09:51Z"
-source_type = "local"
-source = "/Users/rckstrbhushan/.cache/codex-runtimes/codex-primary-runtime/plugins/openai-primary-runtime"
-
 [features]
 js_repl = false
 
-[mcp_servers.node_repl]
-args = []
-command = "/Applications/Codex.app/Contents/Resources/cua_node/bin/node_repl"
-startup_timeout_sec = 120
-
-[mcp_servers.node_repl.env]
-NODE_REPL_NATIVE_PIPE_CONNECT_TIMEOUT_MS = "1000"
-NODE_REPL_NODE_MODULE_DIRS = "/Applications/Codex.app/Contents/Resources/cua_node/lib/node_modules"
-NODE_REPL_NODE_PATH = "/Applications/Codex.app/Contents/Resources/cua_node/bin/node"
-NODE_REPL_TRUSTED_CODE_PATHS = "/Users/rckstrbhushan/.codex"
-CODEX_HOME = "/Users/rckstrbhushan/.codex"
-NODE_REPL_TRUSTED_BROWSER_CLIENT_SHA256S = "72614174f4dad67a58d46a3ac759cffb45c92fa48a293af4c4ea35102ba391ba"
-BROWSER_USE_AVAILABLE_BACKENDS = "chrome,iab"
-NODE_REPL_INSTRUCTIONS_USE_CASE_BROWSER = "Control the in-app browser in conjunction with the Browser Plugin."
-NODE_REPL_INSTRUCTIONS_USE_CASE_CHROME = "Control the Chrome browser in conjunction with the Chrome Plugin. Prefer this method of controlling Chrome over alternatives (such as Computer Use) unless the user explicitly mentions an alternative."
-BROWSER_USE_CODEX_APP_BUILD_FLAVOR = "prod"
-BROWSER_USE_CODEX_APP_VERSION = "26.608.12217"
-CODEX_CLI_PATH = "/Applications/Codex.app/Contents/Resources/codex"
-
-[mcp_servers.zernio]
-url = "https://mcp.zernio.com/mcp"
-bearer_token_env_var = "ZERNIO_API_KEY"
-
-[projects."/Users/rckstrbhushan/code/austa"]
-trust_level = "trusted"
-
-[projects."/Users/rckstrbhushan/code/alfredscholar"]
-trust_level = "trusted"
-
-[projects."/Users/rckstrbhushan/code/automate-alfredscholar-help-docs-carousel"]
-trust_level = "trusted"
-
-[projects."/Users/rckstrbhushan/Documents/scratchpad"]
-trust_level = "trusted"
-
-[projects."/Users/rckstrbhushan/code/dotfiles"]
-trust_level = "trusted"
-
-[plugins."posthog@openai-curated"]
-enabled = true
-
-[plugins."documents@openai-primary-runtime"]
-enabled = true
-
-[plugins."spreadsheets@openai-primary-runtime"]
-enabled = true
-
-[plugins."presentations@openai-primary-runtime"]
-enabled = true
-
-[plugins."browser@openai-bundled"]
-enabled = true
-
-[plugins."chrome@openai-bundled"]
-enabled = true
-
 [desktop]
 git-pull-request-merge-method = "squash"
-
-[desktop.open-in-target-preferences]
-global = "cursor"

--- a/scripts/links.sh
+++ b/scripts/links.sh
@@ -77,7 +77,16 @@ if [[ -L "$HOME/.config/opencode/agents" ]]; then
 fi
 
 # OpenAI Codex CLI
-link agents/codex/config.toml      "$HOME/.codex/config.toml"
+# config.toml is seeded as a real file, not symlinked: Codex writes
+# machine-specific state into it (project trust, marketplaces, notify hooks).
+if [[ -L "$HOME/.codex/config.toml" ]]; then
+  rm "$HOME/.codex/config.toml"
+fi
+if [[ ! -e "$HOME/.codex/config.toml" ]]; then
+  mkdir -p "$HOME/.codex"
+  cp "$DOTFILES/agents/codex/config.toml" "$HOME/.codex/config.toml"
+fi
+echo "  $HOME/.codex/config.toml (seeded, machine-local)"
 link agents/instructions/AGENTS.md "$HOME/.codex/AGENTS.md"
 link agents/commands               "$HOME/.codex/prompts"
 link agents/skills                 "$HOME/.codex/skills"


### PR DESCRIPTION
## Summary

The dotfiles run on multiple Macs with different account names, but `~/.codex/config.toml` was symlinked into the repo while Codex Desktop writes machine-specific state into it (project trust levels, marketplace sources, notify hooks), leaking `/Users/<name>/` absolute paths into git and breaking the other machine.

- Trim `agents/codex/config.toml` to a portable seed: model, reasoning effort, service tier, features, desktop merge preference. No absolute paths.
- `scripts/links.sh` now removes any old symlink and copies the seed to `~/.codex/config.toml` only if the file is missing; Codex owns the local file afterwards, so machine state never reaches the repo.
- Document the seed exception in `agents/README.md` and `CLAUDE.md`, plus an explicit multi-Mac portability rule.

Audited the rest of the tracked tree: `zsh/zshrc` uses `/Users/Shared/` (system-wide, identical on every Mac); OBS overlays contain the handle as on-screen brand text, not paths; `.claude/settings.local.json` and `agents/skills/.system/` are untracked.

## Validation

- `bash -n scripts/links.sh` passes; re-ran `links.sh`, idempotent, local Codex config preserved byte-for-byte
- Seed parses as valid TOML (`tomllib`)
- `git grep` confirms no machine-specific `/Users/<name>/` paths remain in tracked files

🤖 Generated with [Claude Code](https://claude.com/claude-code)