### PR TITLE
fix(install): keep install working across brew tap trust and cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ Non-negotiable: **write the test first, then implement.**
 ```bash
 bash doctor              # AI OS health: symlinks, registries, dead refs, phantom commands
 bash scripts/doctor.test.sh   # unit tests for the doctor checks
+bash scripts/packages.test.sh # install must survive a cleanup failure (brew stubbed)
 cd obs && npm test            # OBS config/scene tests (node --test)
 ```
 
@@ -70,12 +71,13 @@ this repo owns: symlinks pointing into the repo are ours, a tool's own runtime s
 
 | Script | Purpose |
 |--------|---------|
-| `scripts/utils.sh` | Shared helpers (`step`, `link`, `ensure`). Sourced by everything. |
-| `scripts/packages.sh` | Syncs `Brewfile` (installs new, removes unlisted). |
+| `scripts/utils.sh` | Shared helpers (`step`, `warn`, `link`, `ensure`). Sourced by everything. |
+| `scripts/packages.sh` | Syncs `Brewfile` (installs new, removes unlisted). Cleanup is non-fatal. |
 | `scripts/links.sh` | Creates every symlink. |
 | `scripts/apps.sh` | Installs oh-my-zsh, TPM, Composer, Laravel Valet. |
 | `scripts/doctor.sh` | AI OS health checks. Pure functions, sourced by `doctor`. |
 | `scripts/doctor.test.sh` | Tests for the above. |
+| `scripts/packages.test.sh` | Tests that `install` survives a `brew cleanup` failure. |
 
 ## The AI OS (`agents/`)
 

--- a/Brewfile
+++ b/Brewfile
@@ -8,7 +8,11 @@ brew 'libgit2'
 brew 'llhttp'
 brew 'gh'
 brew 'lazygit'
-brew 'anomalyco/tap/opencode'
+# trusted: Homebrew gates third-party taps behind `brew trust`, and `brew bundle
+# cleanup` untrusts formulae whose old kegs it removes, so a manual `brew trust`
+# survives exactly one install. This re-grants it on every run. Scoped to this
+# formula: the tap's others (sst, torpedo) stay untrusted.
+brew 'anomalyco/tap/opencode', trusted: true
 
 # Shell & Terminal Enhancements
 brew 'zsh-syntax-highlighting'

--- a/scripts/packages.sh
+++ b/scripts/packages.sh
@@ -3,4 +3,9 @@ step "Syncing Homebrew packages (this may take a while on first run)..."
 brew bundle --file="$DOTFILES/Brewfile" --verbose
 
 step "Removing packages not in Brewfile..."
-brew bundle cleanup --force --file="$DOTFILES/Brewfile"
+# Opportunistic disk hygiene, never load bearing: root-owned kegs (Valet runs
+# nginx/dnsmasq via `sudo brew services`) make this exit 1 indefinitely. Under
+# install's `set -e` that skipped links.sh and apps.sh entirely, so keep it
+# non-fatal and let the run finish.
+brew bundle cleanup --force --file="$DOTFILES/Brewfile" ||
+  warn "package cleanup incomplete (see above); continuing"

--- a/scripts/packages.test.sh
+++ b/scripts/packages.test.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Tests for scripts/packages.sh, run: bash scripts/packages.test.sh
+#
+# packages.sh is sourced by `install` under `set -e`, so any non-zero command
+# aborts the whole run and silently skips links.sh and apps.sh. These tests pin
+# down which failures are allowed to do that: syncing the Brewfile is load
+# bearing and must abort, cleanup is opportunistic disk hygiene and must not.
+#
+# brew is stubbed on PATH so the tests never touch the real Homebrew.
+
+set -uo pipefail
+
+DOTFILES="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO="$DOTFILES"
+export DOTFILES
+
+_pass=0
+_fail=0
+
+is() { # is <label> <expected> <actual>
+  if [[ "$2" == "$3" ]]; then
+    _pass=$((_pass + 1))
+  else
+    _fail=$((_fail + 1))
+    echo "  FAIL  $1"
+    echo "        expected: [$2]"
+    echo "        actual:   [$3]"
+  fi
+}
+
+# ── Fixture ────────────────────────────────────────────────────────────
+# A stub brew whose failure mode is chosen per-test via $STUB_FAIL_ON:
+# "cleanup" fails only `brew bundle cleanup`, "bundle" fails only the sync.
+
+FIXTURE="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE"' EXIT
+
+mkdir -p "$FIXTURE/bin"
+echo "brew 'git'" >"$FIXTURE/Brewfile"
+
+cat >"$FIXTURE/bin/brew" <<'STUB'
+#!/usr/bin/env bash
+# $1 is always "bundle" here; "cleanup" appears as $2 only for the cleanup call.
+if [[ "${2:-}" == "cleanup" ]]; then
+  [[ "${STUB_FAIL_ON:-}" == "cleanup" ]] && { echo "stub: cleanup failed" >&2; exit 1; }
+  exit 0
+fi
+[[ "${STUB_FAIL_ON:-}" == "bundle" ]] && { echo "stub: bundle failed" >&2; exit 1; }
+exit 0
+STUB
+chmod +x "$FIXTURE/bin/brew"
+
+# run_packages <fail-on> -> prints the exit code install would see
+run_packages() {
+  (
+    set -e
+    export PATH="$FIXTURE/bin:$PATH"
+    export DOTFILES="$FIXTURE"
+    export STUB_FAIL_ON="$1"
+    source "$REPO/scripts/utils.sh"
+    source "$REPO/scripts/packages.sh"
+  ) >/dev/null 2>&1
+  echo $?
+}
+
+# ── Tests ──────────────────────────────────────────────────────────────
+
+is "a healthy run exits 0" \
+  "0" \
+  "$(run_packages none)"
+
+# The regression this file exists for: root-owned kegs left behind by Valet's
+# `sudo brew services` make `brew cleanup` exit 1 forever. Under set -e that
+# aborted install before a single symlink was created, and the failure looked
+# like success because cleanup still prints "freed approximately N MB".
+is "a cleanup failure does not abort install" \
+  "0" \
+  "$(run_packages cleanup)"
+
+# The other half: making cleanup non-fatal must not mask a real sync failure.
+is "a Brewfile sync failure still aborts install" \
+  "1" \
+  "$(run_packages bundle)"
+
+# ── Summary ────────────────────────────────────────────────────────────
+echo ""
+if [[ $_fail -eq 0 ]]; then
+  echo "==> $_pass passed"
+  exit 0
+fi
+echo "==> $_pass passed, $_fail failed"
+exit 1

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -3,6 +3,8 @@
 
 step() { echo ""; echo "==> $*"; }
 
+warn() { echo "  warning: $*" >&2; }
+
 # link <repo-relative-path> <destination>
 # Safe to re-run. Handles both files and directories.
 link() {


### PR DESCRIPTION
## Problem

`bash install` could not run twice in a row. Two independent faults were stacked on top of each other, and the second one hid the first.

**1. Trust was self-erasing.** Homebrew now gates third-party taps behind `brew trust`, and our Brewfile pins `anomalyco/tap/opencode`. But `brew bundle cleanup` *untrusts* formulae whose old kegs it removes — `cmd/uninstall.rb:126` calls `Trust.untrust!`, which empties the store and deletes `~/.homebrew/trust.json`. A manual `brew trust` therefore survived exactly one install:

1. `brew trust` → trusted
2. `install` → bundle succeeds → cleanup silently wipes the trust
3. next `install` → bundle fails, tap untrusted → `set -e` aborts
4. repeat forever

**2. Cleanup aborted the run.** `packages.sh` ended with `brew bundle cleanup`, which exits 1 indefinitely on this machine: root-owned kegs (Valet runs nginx/dnsmasq via `sudo brew services`) can't be chmod'd during cleanup. Under `install`'s `set -e`, that killed the script **before `links.sh` and `apps.sh`** — so no symlinks were ever created. The failure read as success, because cleanup still prints `freed approximately 111.0MB` before exiting non-zero.

## Fix

- **`Brewfile`** — declare `trusted: true` on the opencode entry. This is Homebrew's own mechanism for exactly this case (`bundle/brew.rb`: *"Trust before tapping: installing the tap loads the formula, which triggers the trust check before any later step could grant trust"*). It self-heals: verified that from a deleted `trust.json`, `brew bundle` recreates it. Scoped to the single formula, so `sst` and `torpedo` in that tap stay untrusted.
- **`scripts/packages.sh`** — cleanup is opportunistic disk hygiene, never load bearing. Warn and continue instead of aborting.
- **`scripts/utils.sh`** — add `warn` alongside `step`/`link`/`ensure`.

## Tests

Written first, per the repo's non-negotiable rule. `scripts/packages.test.sh` stubs `brew` on `PATH` and pins **both** halves:

- a cleanup failure must **not** abort install (the regression above)
- a Brewfile sync failure **still must** — so making cleanup non-fatal can't mask a real package failure

## Verification

- `bash install` run twice consecutively from a wiped `trust.json` — both exit 0, zero trust errors, cleanup surfaces as a visible warning
- `bash doctor` → AI OS healthy
- `bash scripts/packages.test.sh` → 3 passed (confirmed it fails against the unfixed code first)
- `bash scripts/doctor.test.sh` → 30 passed
- `cd obs && npm test` → 6 passed

## Not covered

Stale root-owned kegs (`nginx/1.31.1`, `dnsmasq/2.92`, `php@8.4/8.4.22`, ~111MB) still can't be reaped by cleanup — that needs interactive sudo. It's now a warning rather than a failure, so it no longer blocks anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)